### PR TITLE
fix: note triggers block, passthrough visibility, and shortcut key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: Build and Release
+
+on:
+  pull_request:
+    branches: [main]
+    types: [closed]
+    paths:
+      - 'src/**'
+      - 'scripts/**'
+      - 'client/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+
+jobs:
+  build-and-release:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - run: corepack enable
+
+      - run: pnpm install
+
+      - run: pnpm build
+
+      - name: Get version
+        id: version
+        run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+
+      - name: Commit dist
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add dist/
+          git diff --staged --quiet || git commit -m "build: v${{ steps.version.outputs.version }} [skip ci]"
+          git push
+
+      - name: Check if tag exists
+        id: tag_check
+        run: |
+          if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Release
+        if: steps.tag_check.outputs.exists == 'false'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.version.outputs.version }}
+          name: v${{ steps.version.outputs.version }}
+          generate_release_notes: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,37 +116,16 @@ open → changes_requested → discussing → approved
   - `.claude-plugin/marketplace.json`
 
 **分支策略**：
-- `develop` 分支：`.gitignore` 忽略 `dist/`，开发时不跟踪构建产物
-- `main` 分支：`.gitignore` **不忽略** `dist/`，构建产物被 git 跟踪，用于发布
+- `develop` 分支：开发分支，`.gitignore` 忽略 `dist/`
+- `main` 分支：发布分支，`dist/` 被 git 跟踪
 
-**发布流程**（必须严格遵守）：
+**发布流程**：
 
-```bash
-# 1. 在 develop 分支更新版本号（4 个文件）
-# 手动编辑或使用脚本更新 version 字段
+1. 在 `develop` 分支更新版本号（4 个文件）并提交
+2. 创建 PR 合并到 `main`
+3. PR 合并后，GitHub Actions 自动构建、提交 dist/、创建 Release
 
-# 2. 提交版本号变更
-git add package.json client/package.json .claude-plugin/
-git commit -m "chore: bump version to x.x.x"
-
-# 3. 切换到 main 分支
-git checkout main
-
-# 4. 合并 develop
-git merge develop
-
-# 5. 重新构建（关键！切换分支后 dist/ 会被回滚到旧版本）
-pnpm build
-
-# 6. 提交构建产物
-git add dist/
-git commit -m "build: update dist for vx.x.x"
-
-# 7. 推送发布
-git push origin main
-
-# 8. 切回 develop 继续开发
-git checkout develop
-```
-
-⚠️ **注意**：合并到 `main` 后必须重新执行 `pnpm build`，否则 `dist/` 是旧版本（被 git checkout 回滚）。
+> **为什么在 develop 而非 CI 中更新版本号？**
+> - 语义化版本需要人工判断（patch/minor/major）
+> - 4 个文件需同步更新，PR 中可审查一致性
+> - CI 职责是构建发布，不应决定版本号

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -146,9 +146,7 @@ function clearTimeoutWarning() {
 // 快捷键帮助面板
 const showKeyboardHelp = ref(false);
 
-// 快捷键 Approve 连击确认
-const approveShortcutPending = ref(false);
-let approveShortcutTimer: number | null = null;
+// 注：快捷键直接复用 confirmPending 状态，无需单独的确认逻辑
 
 // 选中文本状态（用于 C 键快捷键）
 const hasTextSelection = ref(false);
@@ -668,34 +666,14 @@ function onSelectionChange(data: CommentRequest | null) {
   selectionData.value = data;
 }
 
-// 快捷键 Approve（连击确认）
+// 快捷键 Approve（连击确认）- 复用 confirmPending 状态
 function handleApproveShortcut() {
   // 仅在非只读、非加载状态下触发
   if (isReadOnly.value || loading.value || showSubmittedView.value || isWaitingForAgent.value) {
     return;
   }
 
-  // 第一次按下：进入确认状态
-  if (!approveShortcutPending.value) {
-    approveShortcutPending.value = true;
-
-    // 启动 3 秒倒计时
-    approveShortcutTimer = window.setTimeout(() => {
-      approveShortcutPending.value = false;
-      approveShortcutTimer = null;
-    }, 3000);
-
-    return;
-  }
-
-  // 第二次按下：执行提交
-  if (approveShortcutTimer) {
-    clearTimeout(approveShortcutTimer);
-    approveShortcutTimer = null;
-  }
-  approveShortcutPending.value = false;
-
-  // 执行提交
+  // 直接调用 onSubmitReview，复用其确认逻辑
   onSubmitReview();
 }
 
@@ -797,12 +775,6 @@ onMounted(() => {
 onUnmounted(() => {
   // 注销所有快捷键
   unregisterCallbacks.forEach(fn => fn());
-
-  // 清理快捷键确认定时器
-  if (approveShortcutTimer) {
-    clearTimeout(approveShortcutTimer);
-    approveShortcutTimer = null;
-  }
 });
 </script>
 
@@ -1022,7 +994,7 @@ onUnmounted(() => {
       leave-to-class="opacity-0 translate-y-4"
     >
       <div
-        v-if="approveShortcutPending"
+        v-if="confirmPending"
         class="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 bg-red-600 text-white px-6 py-3 rounded-lg shadow-lg flex items-center gap-3 animate-pulse"
       >
         <span>Press</span>

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -689,9 +689,9 @@ const { register, isMac: isMacKeyboard } = useKeyboard();
 const unregisterCallbacks: Array<() => void> = [];
 
 onMounted(() => {
-  // 全局 Approve 快捷键 (Cmd+Shift+P / Ctrl+Shift+P)
+  // 全局 Approve 快捷键 (Cmd+Shift+Enter / Ctrl+Shift+Enter)
   unregisterCallbacks.push(register({
-    key: 'p',
+    key: 'enter',
     modifiers: { mod: true, shift: true },
     handler: handleApproveShortcut,
     description: 'Approve / Submit Review',
@@ -998,7 +998,7 @@ onUnmounted(() => {
         class="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 bg-red-600 text-white px-6 py-3 rounded-lg shadow-lg flex items-center gap-3 animate-pulse"
       >
         <span>Press</span>
-        <Kbd keys="mod+shift+p" class="!bg-red-800 !border-red-500" />
+        <Kbd keys="mod+shift+enter" class="!bg-red-800 !border-red-500" />
         <span>again to confirm</span>
       </div>
     </Transition>

--- a/client/src/components/ReviewSidebar.vue
+++ b/client/src/components/ReviewSidebar.vue
@@ -58,6 +58,9 @@ function handleApprovalNoteKeydown(e: KeyboardEvent) {
 const unresolvedComments = computed(() => props.comments.filter(c => !c.resolved));
 const resolvedComments = computed(() => props.comments.filter(c => c.resolved));
 
+// 计算属性：是否有全局 note
+const hasNote = computed(() => !!props.approvalNote?.trim());
+
 // 计算属性：是否所有问题都已回答
 const allQuestionsAnswered = computed(() => {
   if (!props.hasQuestions) return true;
@@ -249,8 +252,8 @@ function toggleExpand(c: Comment) {
 
     <!-- Footer -->
     <div class="p-4 border-t border-border-light dark:border-border-dark bg-app-surface-light dark:bg-app-surface-dark transition-colors duration-200">
-      <!-- PassThrough 开关（仅在有未解决评论时显示） -->
-      <div v-if="unresolvedComments.length > 0 && !hasQuestions && !isReadOnly" class="mb-3">
+      <!-- PassThrough 开关（有未解决评论或全局 note 时显示） -->
+      <div v-if="(unresolvedComments.length > 0 || hasNote) && !hasQuestions && !isReadOnly" class="mb-3">
         <PassThroughSwitch
           :model-value="passThrough ?? false"
           @update:model-value="emit('update:passThrough', $event)"


### PR DESCRIPTION
## Summary

- Note 填写后提交（未开启 passThrough）会触发 `changes_requested` 状态
- PassThrough 开关在有 comments 或 note 时显示
- 全局提交快捷键从 `Cmd+Shift+P` 改为 `Cmd+Shift+Enter`
- 添加 GitHub Actions workflow 实现 PR 合并后自动构建和发布

## Test plan

- [ ] 填写 note 后提交，验证触发 block
- [ ] 只有 note 无 comments 时，验证 PassThrough 开关可见
- [ ] 测试 `Cmd+Shift+Enter` 快捷键
- [ ] 验证 GitHub Actions workflow 配置

🤖 Generated with [Claude Code](https://claude.com/claude-code)