### PR TITLE
fix(ci): enable corepack before setup-node for pnpm cache

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,12 +22,12 @@ jobs:
         with:
           ref: main
 
+      - run: corepack enable pnpm
+
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'pnpm'
-
-      - run: corepack enable
 
       - run: pnpm install
 


### PR DESCRIPTION
## Summary

修复 GitHub Actions workflow 失败问题：`setup-node` 的 `cache: pnpm` 需要 pnpm 先可用。

**修复**：将 `corepack enable pnpm` 移到 `setup-node` 之前。

## Test plan

- [ ] Workflow 成功执行
- [ ] dist/ 自动提交到 main
- [ ] Release 自动创建

🤖 Generated with [Claude Code](https://claude.com/claude-code)