### PR TITLE
chore: fix dist/ gitignore for develop branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add dist/
+          git add -f dist/
           git diff --staged --quiet || git commit -m "build: v${{ steps.version.outputs.version }} [skip ci]"
           git push
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ pnpm-debug.log*
 *.tsbuildinfo
 .claude
 .reviews
+dist/


### PR DESCRIPTION
## Summary

修复 develop 分支 dist/ 跟踪问题：

- 在 `.gitignore` 中添加 `dist/`，防止开发者误提交
- 修改 CI workflow 使用 `git add -f dist/` 强制添加，绕过 .gitignore
- 从 develop 分支移除 dist/ 跟踪

## 原理

- `.gitignore` 只影响未跟踪的文件
- `git add -f` 可以强制添加被忽略的文件
- PR 合并后 main 的 .gitignore 也会包含 dist/，但 CI 用 -f 绕过

## Test plan

- [ ] develop 分支 dist/ 不被跟踪
- [ ] CI workflow 成功执行并提交 dist/

🤖 Generated with [Claude Code](https://claude.com/claude-code)